### PR TITLE
Testy dodanie automatycznego testu wywoływanego przy commitach

### DIFF
--- a/docs/assets/css/.github/workflows/.github/workflows/ci.yml
+++ b/docs/assets/css/.github/workflows/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Test MkDocs build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install mkdocs mkdocs-material
+      - name: Build documentation
+        run: mkdocs build --strict
+
+      - name: Lint Markdown files
+        uses: DavidAnson/markdownlint-cli2-action@v16
+        with:
+          globs: '**/*.md'


### PR DESCRIPTION

Test buduje dokumentację MkDocs
Instaluje MkDocs i motyw Material.
Próbuje zbudować dokumentację (mkdocs build --strict).
Jeśli są błędy w plikach lub konfiguracji, test nie przejdzie.
Sprawdza poprawność plików Markdown
Używa narzędzia markdownlint do sprawdzenia stylu i błędów w plikach .md.